### PR TITLE
Properly encode entity states for evaluation

### DIFF
--- a/src/utility/home_assistant/encode_states.ts
+++ b/src/utility/home_assistant/encode_states.ts
@@ -1,0 +1,19 @@
+import { HomeAssistantStates } from './types'
+
+export type States = { [key: string]: unknown }
+
+export function encodeStates(rawStates: HomeAssistantStates) {
+    const states: States = {}
+
+    for (const rawStateName in rawStates) {
+        const { state, attributes } = rawStates[rawStateName]
+
+        states[rawStateName] = state
+
+        for (const attributeName in attributes) {
+            states[`${rawStateName}.${attributeName}`] = attributes[attributeName]
+        }
+    }
+
+    return states
+}

--- a/src/utility/home_assistant/types.ts
+++ b/src/utility/home_assistant/types.ts
@@ -1,3 +1,10 @@
+export type HomeAssistantState = {
+    state: boolean
+    attributes: { [key: string]: unknown }
+}
+
+export type HomeAssistantStates = { [key: string]: HomeAssistantState }
+
 export type HomeAssistant = {
-    entities: unknown
+    states: HomeAssistantStates
 }

--- a/src/visual/index.ts
+++ b/src/visual/index.ts
@@ -2,8 +2,9 @@ import { Configuration } from '@/configuration'
 import { GlobalResourceManager } from '@/global'
 
 import { Evaluator } from '@/utility/evaluater'
+import { encodeStates } from '@/utility/home_assistant/encode_states'
 import { HomeAssistant } from '@/utility/home_assistant/types'
-import { LogLevel, Logger } from '@/utility/logger'
+import { Logger } from '@/utility/logger'
 import { ResourceManager } from '@/utility/resource_manager'
 
 import { Renderer } from './renderer'
@@ -38,7 +39,7 @@ export class Visual {
 
         this.resourceManager = GlobalResourceManager
         this.logger = logger
-        this.evaluator = new Evaluator({ Entities: homeAssistant.entities })
+        this.evaluator = new Evaluator({ Entities: encodeStates(homeAssistant.states) })
 
         this.renderer = new Renderer()
         this.domElement = this.renderer.domElement
@@ -54,7 +55,7 @@ export class Visual {
 
     public updateHomeAssistant(homeAssistant: HomeAssistant) {
         this.homeAssistant = homeAssistant
-        this.evaluator.setContextValue('Entities', homeAssistant.entities)
+        this.evaluator.setContextValue('Entities', encodeStates(homeAssistant.states))
         this.updateProperties()
     }
 


### PR DESCRIPTION
- Switch to using states property of hass object instead of incorrect entities property
- Add a function to encode states into a single key pair object