### PR TITLE
Use height and width scale for card objects

### DIFF
--- a/src/configuration/common.ts
+++ b/src/configuration/common.ts
@@ -1,5 +1,27 @@
 import { Expression } from '@/utility/evaluater'
 
+export type CommonSizeDefaultValue = {
+    width: Expression
+    height: Expression
+}
+
+export class CommonSizeConfiguration {
+    public width: ExpressionConfiguration
+    public height: ExpressionConfiguration
+
+    constructor(raw: any, defaultValue: CommonSizeDefaultValue) {
+        this.width = new ExpressionConfiguration(raw?.width, defaultValue.width)
+        this.height = new ExpressionConfiguration(raw?.height, defaultValue.height)
+    }
+
+    public encode() {
+        return {
+            height: this.height.encode(),
+            width: this.width.encode(),
+        }
+    }
+}
+
 export type Vector3DefaultValue = {
     x: Expression
     y: Expression
@@ -44,17 +66,9 @@ export class CommonScaleConfiguration extends Vector3Configuration {
     }
 }
 
-export class HTMLSizeConfiguration {
-    public height: ExpressionConfiguration
-    public width: ExpressionConfiguration
-
+export class HTMLSizeConfiguration extends CommonSizeConfiguration {
     constructor(raw: any) {
-        this.height = new ExpressionConfiguration(raw?.height, '"200px"')
-        this.width = new ExpressionConfiguration(raw?.width, '"400px"')
-    }
-
-    public encode() {
-        return { height: this.height.encode(), width: this.width.encode() }
+        super(raw, { height: '"auto"', width: '"auto"' })
     }
 }
 

--- a/src/configuration/objects.ts
+++ b/src/configuration/objects.ts
@@ -2,6 +2,7 @@ import {
     CommonPositionConfiguration,
     CommonRotationConfiguration,
     CommonScaleConfiguration,
+    CommonSizeConfiguration,
     ExpressionConfiguration,
     HTMLSizeConfiguration,
 } from './common'
@@ -32,7 +33,7 @@ export class Card3DConfiguration {
     public size: HTMLSizeConfiguration
     public position: CommonPositionConfiguration
     public rotation: CommonRotationConfiguration
-    public scale: CommonScaleConfiguration
+    public scale: CommonSizeConfiguration
     public visible: ExpressionConfiguration
 
     constructor(raw: any) {
@@ -40,7 +41,7 @@ export class Card3DConfiguration {
         this.size = new HTMLSizeConfiguration(raw?.size)
         this.position = new CommonPositionConfiguration(raw?.position)
         this.rotation = new CommonPositionConfiguration(raw?.rotation)
-        this.scale = new CommonPositionConfiguration(raw?.scale)
+        this.scale = new CommonSizeConfiguration(raw?.scale, { height: '1', width: '1' })
         this.visible = new ExpressionConfiguration(raw?.visible, 'true')
     }
 
@@ -62,7 +63,7 @@ export class Card2DConfiguration {
     public size: HTMLSizeConfiguration
     public position: CommonPositionConfiguration
     public rotation: CommonRotationConfiguration
-    public scale: CommonScaleConfiguration
+    public scale: CommonSizeConfiguration
     public visible: ExpressionConfiguration
 
     constructor(raw: any) {
@@ -70,7 +71,7 @@ export class Card2DConfiguration {
         this.size = new HTMLSizeConfiguration(raw?.size)
         this.position = new CommonPositionConfiguration(raw?.position)
         this.rotation = new CommonPositionConfiguration(raw?.rotation)
-        this.scale = new CommonPositionConfiguration(raw?.scale)
+        this.scale = new CommonSizeConfiguration(raw?.scale, { height: '1', width: '1' })
         this.visible = new ExpressionConfiguration(raw?.visible, 'true')
     }
 

--- a/src/elements/card/index.tsx
+++ b/src/elements/card/index.tsx
@@ -173,9 +173,8 @@ const DefaultConfiguration = new Configuration({
                         z: '0',
                     },
                     scale: {
-                        x: '1',
-                        y: '1',
-                        z: '1',
+                        height: '1',
+                        width: '1',
                     },
                     visible: 'true',
                 },

--- a/src/visual/scene/objects/2d_card.ts
+++ b/src/visual/scene/objects/2d_card.ts
@@ -222,27 +222,21 @@ export class Card2D {
     }
 
     private updateScale(configuration: Card2DConfiguration['scale'], evaluator: Evaluator) {
-        let x, y, z
+        let width, height
 
         try {
-            x = evaluator.evaluate<number>(configuration.x.value)
+            width = evaluator.evaluate<number>(configuration.width.value)
         } catch (error) {
-            throw new Error(`${configuration.x.encode()}: Error evaluating x expression`, error)
+            throw new Error(`${configuration.height.encode()}: Error evaluating width expression`, error)
         }
 
         try {
-            y = evaluator.evaluate<number>(configuration.y.value)
+            height = evaluator.evaluate<number>(configuration.height.value)
         } catch (error) {
-            throw new Error(`${configuration.y.encode()}: Error evaluating y expression`, error)
+            throw new Error(`${configuration.height.encode()}: Error evaluating height expression`, error)
         }
 
-        try {
-            z = evaluator.evaluate<number>(configuration.z.value)
-        } catch (error) {
-            throw new Error(`${configuration.z.encode()}: Error evaluating z expression`, error)
-        }
-
-        this.three.scale.set(x, y, z)
+        this.three.scale.set(width, height, 1)
     }
 
     private async loadCard(configuration: Card2DConfiguration['config']) {

--- a/src/visual/scene/objects/3d_card.ts
+++ b/src/visual/scene/objects/3d_card.ts
@@ -222,27 +222,21 @@ export class Card3D {
     }
 
     private updateScale(configuration: Card3DConfiguration['scale'], evaluator: Evaluator) {
-        let x, y, z
+        let width, height
 
         try {
-            x = evaluator.evaluate<number>(configuration.x.value)
+            width = evaluator.evaluate<number>(configuration.width.value)
         } catch (error) {
-            throw new Error(`${configuration.x.encode()}: Error evaluating x expression`, error)
+            throw new Error(`${configuration.height.encode()}: Error evaluating width expression`, error)
         }
 
         try {
-            y = evaluator.evaluate<number>(configuration.y.value)
+            height = evaluator.evaluate<number>(configuration.height.value)
         } catch (error) {
-            throw new Error(`${configuration.y.encode()}: Error evaluating y expression`, error)
+            throw new Error(`${configuration.height.encode()}: Error evaluating height expression`, error)
         }
 
-        try {
-            z = evaluator.evaluate<number>(configuration.z.value)
-        } catch (error) {
-            throw new Error(`${configuration.z.encode()}: Error evaluating z expression`, error)
-        }
-
-        this.three.scale.set(x, y, z)
+        this.three.scale.set(width, height, 1)
     }
 
     private async loadCard(configuration: Card3DConfiguration['config']) {


### PR DESCRIPTION
- Instead of x, y, z values, use height and width for scalling 3D and 2D card